### PR TITLE
Fixed failing MAKE for celma

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-latest
     container: loeiten/celma_env:latest
     strategy:
       fail-fast: true

--- a/celma/celma.hxx
+++ b/celma/celma.hxx
@@ -17,6 +17,7 @@
 #include <invert_laplace.hxx> // Gives invert laplace option
 #include <map>                // Gives std::map
 #include <vecops.hxx>         // Gives the vec diff options
+#include <string>
 // Gives own boundaries (doing so by setting ghost points)
 #include "../common/BOUTExtensions/include/ownBCs.hxx"
 // Gives own operators
@@ -148,7 +149,7 @@ private:
 
   // Additional methods and solvers
   // *****************************************************************************
-  string ownOpType;  // Type of own operators
+  std::string ownOpType;  // Type of own operators
   BRACKET_METHOD bm; // The bracket method
   OwnBCs ownBC;      // Class containing methods which sets the ghost points
   OwnLaplacianInversions ownLapl; // Class containing own laplacian

--- a/common/BOUTExtensions/include/ownBCs.hxx
+++ b/common/BOUTExtensions/include/ownBCs.hxx
@@ -3,6 +3,7 @@
 
 #include <bout.hxx>           // Includes all necessary classes and types
 #include <bout/constants.hxx> // Gives PI and TWOPI
+#include <string>
 
 /*!
  * \class OwnBCs
@@ -85,10 +86,10 @@ public:
                    bool const &yUpExtrapolate = true);
   /**@{*/
   //! Wrapper which initialize Cauchy
-  void prepareCauchy(const string &section);
+  void prepareCauchy(const std::string &section);
   //! Specify the lower ghost from the Cauchy boundary condition
-  void getAFunction(const string &section);
-  void getBFunction(const string &section);
+  void getAFunction(const std::string &section);
+  void getBFunction(const std::string &section);
   /**@}*/
   //! Get the value of y at the boundary
   void getYValAtYDownBndry();

--- a/common/BOUTExtensions/include/ownLaplacianInversions.hxx
+++ b/common/BOUTExtensions/include/ownLaplacianInversions.hxx
@@ -4,6 +4,7 @@
 #include "ownBCs.hxx"       // Must know about the boundary conditions
 #include "ownOperators.hxx" // Must know about the operators class
 #include <bout.hxx>         // Includes all necessary classes and types
+#include <string>
 
 /*!
  * \class OwnLaplacianInversions
@@ -46,7 +47,7 @@ public:
   // Member functions
   //! Alternative to a constructor
   void create(OwnOperators *opObj, OwnBCs &BCObj,
-              const string &section = "phiSolver");
+              const std::string &section = "phiSolver");
   //! The NaulinSolver
   Field3D NaulinSolver(const Vector3D &gradPerpLnN, const Field3D &n,
                        const Field3D &vortD, const Field3D &phiInit,

--- a/common/BOUTExtensions/src/helpers.cxx
+++ b/common/BOUTExtensions/src/helpers.cxx
@@ -72,14 +72,16 @@ BoutReal VolumeIntegral::volumeIntegral(Field3D const &f) {
   BoutReal result = 0.0;
   BoutReal localResult = 0.0;
 
+  Coordinates *coord = mesh->getCoordinates();
+
   // We loop over the processor domain
   for (xInd = mesh->xstart; xInd <= mesh->xend; xInd++) {
     for (yInd = mesh->ystart; yInd <= mesh->yend; yInd++) {
       for (zInd = 0; zInd < mesh->LocalNz; zInd++) {
         localResult +=
-            f(xInd, yInd, zInd) * mesh->coordinates()->J(xInd, yInd) *
-            mesh->coordinates()->dx(xInd, yInd) *
-            mesh->coordinates()->dy(xInd, yInd) * mesh->coordinates()->dz;
+            f(xInd, yInd, zInd) * coord->J(xInd, yInd) *
+            coord->dx(xInd, yInd) *
+            coord->dy(xInd, yInd) * coord->dz;
       }
     }
   }

--- a/common/BOUTExtensions/src/ownBCs.cxx
+++ b/common/BOUTExtensions/src/ownBCs.cxx
@@ -2,6 +2,7 @@
 #define __OWNBCS_CXX__
 
 #include "../include/ownBCs.hxx"
+#include <string>
 
 /*!
  * \brief Constructor
@@ -510,7 +511,7 @@ void OwnBCs::parDensMomSheath(Field3D &momDensPar, const Field3D &uIPar,
 void OwnBCs::cauchyYDown(Field3D &f, const BoutReal &t,
                          bool const &yUpExtrapolate) {
   TRACE("Halt in OwnBCs::cauchyYDown");
-
+  Coordinates *coord = mesh->getCoordinates();
   if (mesh->firstY()) {
     for (int xInd = mesh->xstart; xInd <= mesh->xend; xInd++) {
       // Calculate the x for the current xIndex
@@ -531,17 +532,17 @@ void OwnBCs::cauchyYDown(Field3D &f, const BoutReal &t,
         b = bBndryFuncGen->generate(x, yValAtYDownBndry, z, t);
         // Set the ghost point
         f(xInd, firstLowerYGhost, zInd) =
-            (1.0 / (120.0 * mesh->coordinates()->dy(xInd, firstLowerYGhost) -
+            (1.0 / (120.0 * coord->dy(xInd, firstLowerYGhost) -
                     115.0)) *
-            (-15.0 * (24.0 * mesh->coordinates()->dy(xInd, firstLowerYGhost) +
+            (-15.0 * (24.0 * coord->dy(xInd, firstLowerYGhost) +
                       7.0) *
                  f(xInd, firstLowerYGhost + 1, zInd) +
              15.0 *
-                 (8.0 * mesh->coordinates()->dy(xInd, firstLowerYGhost) - 1.0) *
+                 (8.0 * coord->dy(xInd, firstLowerYGhost) - 1.0) *
                  f(xInd, firstLowerYGhost + 2, zInd) -
-             (24.0 * mesh->coordinates()->dy(xInd, firstLowerYGhost) - 5.0) *
+             (24.0 * coord->dy(xInd, firstLowerYGhost) - 5.0) *
                  f(xInd, firstLowerYGhost + 3, zInd) +
-             (24.0 * mesh->coordinates()->dy(xInd, firstLowerYGhost)) *
+             (24.0 * coord->dy(xInd, firstLowerYGhost)) *
                  (16.0 * a + 5.0 * b));
       }
     }
@@ -567,7 +568,7 @@ void OwnBCs::cauchyYDown(Field3D &f, const BoutReal &t,
  * \sa getBFunction
  * \sa getYValAtYDownBndry
  */
-void OwnBCs::prepareCauchy(const string &section) {
+void OwnBCs::prepareCauchy(const std::string &section) {
   TRACE("Halt in OwnBCs::prepareCauchy");
 
   output << "\n\n\n!!!WARNING: Only first order convergence found with "
@@ -588,11 +589,11 @@ void OwnBCs::prepareCauchy(const string &section) {
  *
  * \sa getBFunction
  */
-void OwnBCs::getAFunction(const string &section) {
+void OwnBCs::getAFunction(const std::string &section) {
   TRACE("Halt in OwnBCs::getAFunction");
   // Get the function
   Options *varOptions = Options::getRoot()->getSection(section);
-  string bndryFuncString;
+  std::string bndryFuncString;
   // Last argument in get is the default
   varOptions->get("a", bndryFuncString, "");
   if (bndryFuncString == "") {
@@ -619,11 +620,11 @@ void OwnBCs::getAFunction(const string &section) {
  *
  * \sa getAFunction
  */
-void OwnBCs::getBFunction(const string &section) {
+void OwnBCs::getBFunction(const std::string &section) {
   TRACE("Halt in OwnBCs::getBFunction");
   // Get the function
   Options *varOptions = Options::getRoot()->getSection(section);
-  string bndryFuncString;
+  std::string bndryFuncString;
   // Last argument in get is the default
   varOptions->get("b", bndryFuncString, "");
   if (bndryFuncString == "") {

--- a/common/BOUTExtensions/src/ownLaplacianInversions.cxx
+++ b/common/BOUTExtensions/src/ownLaplacianInversions.cxx
@@ -2,6 +2,7 @@
 #define __OWNLAPLACIANINVERSIONS_CXX__
 
 #include "../include/ownLaplacianInversions.hxx"
+#include <string>
 
 /*!
  * This function is used instead of a constructor as a OwnOperators and a
@@ -13,7 +14,7 @@
  * \param[in] section Section to read the input data from
  */
 void OwnLaplacianInversions::create(OwnOperators *opObj, OwnBCs &BCObj,
-                                    const string &section) {
+                                    const std::string &section) {
 
   TRACE("Halt in OwnLaplacianInversions::OwnLaplacianInversions");
 

--- a/common/BOUTExtensions/src/ownOperators.cxx
+++ b/common/BOUTExtensions/src/ownOperators.cxx
@@ -4,6 +4,7 @@
 #include "../include/ownOperators.hxx"
 #include <fft.hxx>           //Includes the FFT
 #include <interpolation.hxx> //Includes the interpolation
+#include <string>
 
 // OwnOperators
 
@@ -18,11 +19,12 @@
 OwnOperators::OwnOperators() {
   TRACE("Halt in OwnOperators::OwnOperators");
 
+  Coordinates *coord = mesh->getCoordinates();
   // Calculate the powers of the Jacobian
   // ************************************************************************
-  J = mesh->coordinates()->J;
-  J2 = pow(mesh->coordinates()->J, (2.0));
-  invJ = 1.0 / (mesh->coordinates()->J);
+  J = coord->J;
+  J2 = pow(coord->J, (2.0));
+  invJ = 1.0 / (coord->J);
   // ************************************************************************
 }
 
@@ -37,7 +39,7 @@ OwnOperators *OwnOperators::createOperators(Options *options) {
     options = Options::getRoot()->getSection("ownOperators");
   }
 
-  string type;
+  std::string type;
   options->get("type", type, "BasicBrackets");
 
   if (lowercase(type) == lowercase("BasicBrackets")) {
@@ -218,7 +220,7 @@ Field3D OwnOpBasicBrackets::kinEnAdvN(const Field3D &phi, const Field3D &n) {
   // Communicate before taking new derivative
   mesh->communicate(DDXPhi);
 
-  result = bracket(pow(DDXPhi, 2.0) + pow(invJ * DDZ(phi, true), 2.0), n, bm);
+  result = bracket(pow(DDXPhi, 2.0) + pow(invJ * DDZ(phi), 2.0), n, bm);
 
   // Multiply with B/2
   return 0.5 * invJ * result;


### PR DESCRIPTION
NOTE:
DDZ have changed from DDZ(Field3D&f, bool inc_xbndry)
to DDZ(Field3D &f), which is RNG_NOBNDRY by default.

See original BOUT-dev commit for original implimentation

This closes #30 